### PR TITLE
fix: broken link to manage account keys

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -154,7 +154,7 @@ npm run-script build
 
 To upload the final bundled templates to our cloud you must have an API Key.
 
-[**Click here to manage your keys 🔑**](https://flayyer.com/settings/keys)
+[**Click here to manage your keys 🔑**](https://flayyer.com/dashboard/settings)
 
 <Tabs groupId="js-manager" defaultValue="yarn" values={jsManagers}>
 <TabItem value="yarn">


### PR DESCRIPTION
In the new UI that you guys publish yesterday have a new link to manage the keys of the account, with this PR fix that issue of 404 page not found